### PR TITLE
improving policies indentation

### DIFF
--- a/docs/api/.gitignore
+++ b/docs/api/.gitignore
@@ -2,3 +2,4 @@
 *
 # Except this file
 !.gitignore
+!orb_rest_api.md

--- a/docs/api/orb_rest_api.md
+++ b/docs/api/orb_rest_api.md
@@ -1,0 +1,6 @@
+# Orb REST API Docs
+Follow the links below for API documentation of each respective Orb microservice:
+
+* [Fleet](https://orb.community/api/fleet.html)
+* [Policies](https://orb.community/api/policies.html)
+* [Sinks](https://orb.community/api/sinks.html)

--- a/docs/documentation/advanced_policies.md
+++ b/docs/documentation/advanced_policies.md
@@ -1,277 +1,4 @@
-# Documentation
-
-## Running Orb Agent
-
-An Orb agent needs to run on all the infrastructure (computers, servers, switches, VMs, k8s, etc.) to be monitored. It is a small, lightweight Docker process with an embedded [pktvisor agent](https://pktvisor.dev) which connects into the Orb control plane to receive policies and send its metric output.
-
-To run an agent, you will need:
-
-1. Docker, to run the agent image ([ns1labs/orb-agent:develop](https://hub.docker.com/repository/docker/ns1labs/orb-agent))
-2. [Agent Credentials](#agent-credentials), which are provided to you by the Orb UI or REST API after [creating an agent](/docs/#create-an-agent)
-3. The Orb Control Plane host address (e.g. `localhost` or `orb.live`)
-4. The network interface to monitor (e.g. `eth0`)
-
-!!! tip 
-
-    If you are unsure which network interface to monitor, you may list the available interfaces on your host. Note that to allow 
-    the agent access to these interfaces, you must run the container with `--net=host`
-    
-
-    === "Linux"
-
-        ``` shell 
-        ip -stats -color -human addr
-        ```
-
-
-    === "OSX"
-
-        ``` shell 
-        ifconfig
-        ```
-
-### Agent credentials 
-
-The agent credentials include *three pieces of information*, each of which is a UUID in the form `5dc34ded-6a53-44c0-8d15-7e9c8c95391a`.
-
-1. **Agent ID**, which uniquely identifies the agent.
-2. **Agent Channel ID**, which uniquely identifies the agent's communication channel.
-3. **Agent Key**, which is a private access token for the agent. Note you will only be shown the key once upon creation!
-
-### Sample provisioning commands
-!!! example  
-
-    === "Generic"
-
-        Use this command as a template by substituting in the appropriate values:
-
-        ``` shell 
-        docker run -d --net=host
-        -e ORB_CLOUD_ADDRESS=<HOST>
-        -e ORB_CLOUD_MQTT_ID=<AGENTID>
-        -e ORB_CLOUD_MQTT_CHANNEL_ID=<CHANNELID>
-        -e ORB_CLOUD_MQTT_KEY=<AGENTKEY>
-        -e PKTVISOR_PCAP_IFACE_DEFAULT=mock
-        ns1labs/orb-agent:develop
-        ```
-    === "localhost, mock"
-        
-        This command is useful for connecting to a local develop environment, perhaps running on [Docker compose](/install/#orb-with-docker-compose). 
-        Note that the "mock" interface will generate random traffic rather than observe real traffic.
-
-        ``` shell 
-        docker run -d --net=host
-        -e ORB_CLOUD_ADDRESS=localhost
-        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
-        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
-        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
-        -e PKTVISOR_PCAP_IFACE_DEFAULT=mock
-        -e ORB_TLS_VERIFY=false
-        ns1labs/orb-agent:develop
-        ```
-
-    === "orb.live, eth0"
-        
-        This command is similar to one you would use on the orb.live SaaS platform
-
-        ``` shell 
-        docker run -d --net=host
-        -e ORB_CLOUD_ADDRESS=orb.live
-        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
-        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
-        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
-        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
-        ns1labs/orb-agent:develop
-        ```
-
-    === "You may want to run more than one agent on the same node and for that you must specify different pktvisor control ports for them, since the containers run in host networking mode, only one is allowed to run per port. By default, the pktvisor control port runs on port *10853*, but this value can be set through the environment variable `ORB_BACKENDS_PKTVISOR_API_PORT`"
-
-
-        ``` shell 
-        docker run -d --net=host
-        -e ORB_CLOUD_ADDRESS=orb.live
-        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
-        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
-        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
-        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
-        -e ORB_BACKENDS_PKTVISOR_API_PORT=10854
-        ns1labs/orb-agent:develop
-        ```
-
-    === "🎁 BONUS - you can access agent debug logs by passing the -d command"
-
-
-        ``` shell 
-        docker run -d --net=host
-        -e ORB_CLOUD_ADDRESS=orb.live
-        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
-        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
-        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
-        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
-        ns1labs/orb-agent:develop run -d
-        ```
-
-!!! question 
-
-    Is the agent Docker image not starting correctly? Do you have a specific use case? Have you found a bug? Come talk to us [live on Slack](https://join.slack.com/t/ns1labs/shared_invite/zt-qqsm5cb4-9fsq1xa~R3h~nX6W0sJzmA),
-    or [file a GitHub issue here](https://github.com/ns1labs/orb/issues/new/choose).
-
-### Configuration files
-
-Most configuration options can be passed to the container as environment variables, but there are some situations that require a configuration file.
-
-You will need to use a configuration file if:
-
-* You want to assign tags to the agent at the edge
-* You want to setup custom pktvisor Taps
-* You want the agent to [auto-provision](#advanced-auto-provisioning-setup)
-
-The configuration file is written in YAML. 
-You can use the latest [template configuration file](https://raw.githubusercontent.com/ns1labs/orb/develop/cmd/agent/agent.example.yaml) as a starting point, or
-start here:
-
-```yaml
-version: "1.0"
-
-# this section is used by pktvisor
-# see https://github.com/ns1labs/pktvisor/blob/develop/RFCs/2021-04-16-75-taps.md
-visor:
-   taps:
-      default_pcap:
-         input_type: pcap
-         config:
-            iface: "eth0"
-            host_spec: "192.168.0.54/32,192.168.0.55/32,127.0.0.1/32"
-
-# this section is used orb-agent
-# most sections and keys are optional
-orb:
-   # these are arbitrary key value pairs used for organization in the control plane and UI
-   tags:
-      region: EU
-      pop: ams02
-      node_type: dns
-   cloud:
-      config:
-         # optionally specify an agent name to use during auto provisioning
-         # hostname will be used if it's not specified here
-         agent_name: my-agent1
-         auto_provision: true
-      api:
-         address: https://orb.live
-         # if auto provisioning, specify API token here (or pass on the command line)
-         token: TOKEN
-      mqtt:
-         address: tls://orb.live:8883
-         # if not auto provisioning, specify agent connection details here
-         id: "AGENT_UUID"
-         key: "AGENT_KEY_UUID"
-         channel_id: "AGENT_CHANNEL_UUID"
-   backends:
-      pktvisor:
-      binary: "/usr/local/sbin/pktvisord"
-      # this example assumes the file is saved as agent.yaml. If your file has another name, you must replace it with the proper name
-      config_file: "/usr/local/orb/etc/agent.yaml"
-```
-
-You must mount your configuration file into the `orb-agent` container. For example, if your configuration file
-is on the host at `/local/orb/agent.yaml`, you can mount it into the container with this command:
-
-```shell
-docker run -v /local/orb:/usr/local/orb/ --net=host \
-      ns1labs/orb-agent:develop run -c /usr/local/orb/agent.yaml
-```
-
-### Advanced auto-provisioning setup
-Some use cases require a way to provision agents directly on edge infrastructure without creating an agent manually in the UI or REST API ahead of time. To do so, you will need to create an API key which can be used by `orb-agent` to provision itself.
-
-!!! warning
-
-    Auto-provisioning is an advanced use case. Most users will find [creating an agent in the UI](/docs/#create-an-agent) easier.
-
-1. If you have not already done so, register a new account with an email address and password at https://HOST/auth/register.
-
-2. Create a `SESSION_TOKEN` with the `EMAIL_ADDRESS` and `PASSWORD` from registration:
-
-        curl --location --request POST 'https://HOST/api/v1/tokens' \
-        --header 'Content-Type: application/json' \
-        --data-raw '{
-        "email": "<EMAIL_ADDRESS>",
-        "password": "<PASSWORD>"
-        }'
-
-3. The output from creating a session token looks like this:
-
-        {
-            "token": "SESSION_TOKEN"
-        }
-
-4. Because session tokens expire after 24 hours, you can create a permanent API token for agent provisioning by using the `SESSION_TOKEN` above:
-
-        curl --location --request POST 'https://HOST/api/v1/keys' \
-        --header 'Authorization: <SESSION_TOKEN>' \
-        --header 'Content-Type: application/json' \
-        --data-raw '{
-        "type": 2
-        }'
-
-5. The output from creating a `PERMANENT_TOKEN` looks like the following. Please take note of the `id` (used later to revoke) and the `value` (the permanent API token):
-
-        {
-            "id": "710c6a92-b463-42ec-bf24-8ae24eb13081",
-            "value": "PERMANENT_TOKEN",
-            "issued_at": "2021-09-07T15:29:49.70146088Z"
-        }
-
-6. **Currently, the permanent token allows access to all API functionality, not just provisioning.** You can revoke this permanent token at any time with the following call, using the `id` field above:
-
-        curl --location --request DELETE 'HOST:80/api/v1/keys/<PERMANENT_TOKEN_ID>' \
-        --header 'Authorization: <SESSION_TOKEN>'
-
-7. Create a config for Orb and pktvisor taps, for example, `/local/orb/agent.yaml`:
-```yaml
-version: "1.0"
-
-visor:
-   taps:
-      ethernet:
-         input_type: pcap
-         config:
-            iface: "eth0"
-
-orb:
-   db:
-      file: /usr/local/orb/orb-agent.db
-   tags:
-      region: EU
-      pop: ams02
-      node_type: dns
-   cloud:
-      config:
-         agent_name: myagent1
-      api:
-         address: https://HOST
-      mqtt:
-         address: tls://HOST:8883
-```
-
-8. You can now pull and run `ns1labs/orb-agent:develop` to auto-provision, substituting in the `PERMANENT_TOKEN` and optionally configuring agent name and Orb tags. If you don't set the agent name, it will attempt to use a hostname. You must mount the directory to save the agent state database and the config file:
-
-```shell
-docker pull ns1labs/orb-agent:develop
-docker run -v /local/orb:/usr/local/orb/ --net=host \
-       -e ORB_CLOUD_API_TOKEN=<PERMANENT_TOKEN> \
-      ns1labs/orb-agent:develop run -c /usr/local/orb/agent.yaml
-```
-
-## Orb REST API Docs
-Follow the links below for API documentation of each respective Orb microservice:
-
-* [Fleet](https://orb.community/api/fleet.html)
-* [Policies](https://orb.community/api/policies.html)
-* [Sinks](https://orb.community/api/sinks.html)
-
-## Advanced Policies
+# Advanced Policies
 
 An Orb policy for pktvisor can be written in either JSON or YAML, and has three top level sections: “input”, “handlers” and “kind”.
 
@@ -287,7 +14,7 @@ An Orb policy for pktvisor can be written in either JSON or YAML, and has three 
 }
 
 ```
-### Input section
+## Input section
 
 The input section specifies what data streams the policy will be using for analysis, in other words, this specifies what data the agent should be listening in on, and is defined at the agent level. <br>
 3 types of input are supported: `pcap`, `flow` and `dnstap`. For each input type, specific configuration, filters and tags can be defined.<br><br>
@@ -304,8 +31,9 @@ If `tap_selector` is used, it can be chosen whether taps with any of the tags or
 
 Every configuration set at the input can be reset at the tap level, with the one set on the tap dominant over the one set on the input.<br>
 
-Default input structure:
+**Default input structure:**
 
+*Using specific tap:*
 ```yaml
 input:
   tap: tap_name
@@ -316,7 +44,7 @@ input:
     ...
 ```
 
-or
+*or using tap selector matching any:*
 
 ```yaml
 input:
@@ -331,7 +59,7 @@ input:
     ...
 ```
 
-or
+*or using tap selector matching all:*
 
 ```yaml
 input:
@@ -346,11 +74,11 @@ input:
     ...
 ```
 
-#### Packet Capture (pcap) 
+### Packet Capture (pcap) 
+
+#### Configurations
 
 There are 5 configurations for pcap input: `pcap_file`, `pcap_source`, `iface`, `host_spec` and `debug`.
-
-**Configurations**:
 
 |   Config    | Type |
 |:-----------:|:-----|
@@ -414,7 +142,10 @@ host_spec: "192.168.0.1/24"
 
 
 
-**filter**:
+#### Filters
+
+There is only one filter referring to the input PCAP: `bpf`.
+
 
 `bpf`: *str* <br>
 
@@ -431,9 +162,9 @@ bpf: "port 53"
 ```
 
 
-#### sflow/Netflow (flow)
+### Sflow/Netflow (flow)
 
-**Configurations**:
+#### Configurations
 
 There are 4 configs for flow inputs: `pcap_file`, `port`, `bind` and `flow_type`. `pcap_file` and `port+bind` are mutually exclusive and one of them must exist.
 
@@ -484,7 +215,14 @@ Example:
 flow_type: netflow
 ```
 
-####  dnstap
+#### Filters
+
+There are no specific filters for the FLOW input.
+
+###  Dnstap
+
+#### Configurations
+
 The 3 existing DNSTAP configurations (`dnstap_file`, `socket` and `tcp`) are mutually exclusive, that is, only one can be used in each input and one of them must exist. They are arranged in order of priority. <br>
 
 |   Config    | Type |
@@ -525,7 +263,7 @@ Example:
  ```
 
 
-**filters**:
+#### Filters
 
 `only_hosts`:
 
@@ -542,10 +280,11 @@ Example:
  ```
 
 
-### Handlers section (Analysis)
+## Handlers section (Analysis)
 
 Handlers are the modules responsible for extracting metrics from inputs. For each handler type, specific configuration, filters and group of metrics can be defined, and there are also configs (abstract configuration) that can be applied to all handlers: <br><br>
-**Abstract Configurations**: <br>
+
+### Abstract Configurations
 
 There are general configurations, which can be applied to all handlers. These settings can be reset for each module, within the specific module configs. In this case, the configuration inside the module will override the configuration passed in general handler. <br>
 
@@ -556,7 +295,7 @@ There are general configurations, which can be applied to all handlers. These se
 |      `topn_count`      | *int* |        10        |
 
 
-##### deep_sample_rate <br>
+**deep_sample_rate** <br>
 
 `deep_sample_rate` determines the number of data packets that will be analyzed deeply per second. Some metrics are operationally expensive to generate, such as metrics that require string parsing (qname2, qtype, etc.). For this reason, a maximum number of packets per second to be analyzed is determined. If in one second fewer packages than the maximum amount are transacted, all packages will compose the deep metrics sample, if there are more packages than the established one, the value of the variable will be used. Allowed values are in the range [1,100]. Default value is 100. <br>
 * If a value less than 1 is passed, the `deep_sample_rate` will be 1. If the value passed is more than 100, `deep_sample_rate` will be 100.
@@ -568,7 +307,7 @@ deep_sample_rate: int
 ```
 
 
-##### num_periods <br>
+**num_periods** <br>
 
 `num_periods` determines the amount of minutes of data that will be available on the metrics endpoint. Allowed values are in the range [2,10]. Default value is 5. <br>
 
@@ -578,7 +317,7 @@ num_periods: int
 ```
 
 
-#### topn_count <br>
+**topn_count** <br>
 
 `topn_count` sets the maximum amount of elements displayed in top metrics. If there is less quantity than the configured value, the composite metrics will have the existing value. But if there are more metrics than the configured value, the variable will be actively limiting. Any positive integer is valid and the default value is 10. <br>
 
@@ -587,8 +326,7 @@ The `topn_count` filter usage syntax is:<br>
 topn_count: int
 ```
 
-
-Default handler structure:
+**Default handler structure:**
 
 ```yaml
 handlers:
@@ -607,7 +345,7 @@ handlers:
         disable:
           - ...
  
- ```
+```
 
 To enable any metric group use the syntax:
 
@@ -631,7 +369,7 @@ metric_groups:
 ### DNS Analyzer (dns)
 **Handler Type**: "dns" <br>
 
-**Metrics Group**: <br>
+#### Metrics Group <br>
 
 |   Metric Group    | Default  | 
 |:-----------------:|:--------:|
@@ -642,11 +380,11 @@ metric_groups:
 |   `top_qnames`    | enabled  |
 <br>
 
-**Configuration**: <br>
+#### Configurations <br>
 - public_suffix_list: *bool*. <br>
 - Abstract configurations. <br><br>
 
-##### public_suffix_list <br>
+**public_suffix_list** <br>
 
 Some names to be resolved by a dns server have public suffixes. These suffixes cause metrics to be generated considering non-relevant data. <br>
 
@@ -665,8 +403,7 @@ public_suffix_list: true
 ```
 
 
-
-**DNS Filter Options**: <br>
+#### Filters <br>
 
 |         Filter         |  Type   | Input  |
 |:----------------------:|:-------:|:------:|
@@ -682,7 +419,7 @@ public_suffix_list: true
 
 
 
-##### only_rcode: *int*. <br>
+**only_rcode:** *int*. <br>
 
 Input: PCAP <br>
 When a DNS server returns a response to a query made, one of the properties of the response is the "return code" (rcode), a code that describes what happened to the query that was made. <br>  
@@ -709,7 +446,7 @@ only_rcode: 0
 ```
 Important information is that only one return code is possible for each handler. So, in order to have multiple filters on the same policy, multiple handlers must be created, each with a rcode type;
 
-####  exclude_noerror: *bool* <br>
+**exclude_noerror:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -721,7 +458,7 @@ exclude_noerror: true
 
 Attention: the filter of `exclude_noerror` is dominant in relation to the filter of only_rcode, that is, if the filter of `exclude_noerror` is true, even if the filter of only_rcode is set, the results will be composed only by responses without any type of error (all type of errors will be kept). <br>
 
-#####  only_dnssec_response: *bool* <br>
+**only_dnssec_response:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -732,7 +469,7 @@ The `only_dnssec_response` filter usage syntax is:<br>
 only_dnssec_response: true
 ```
 
-#####  answer_count: *int* <br>
+**answer_count:** *int* <br>
 
 Input: PCAP <br>
 
@@ -754,7 +491,7 @@ In this case, to have in the results only the cases of `NODATA`, that is, the re
 
 Important information is that only one answer_count is possible for each handler. So, in order to have multiple counts on the same policy, multiple handlers must be created, each with an amount of answers;
 
-####  only_qtype: *str[]* <br>
+**only_qtype:** *str[]* <br>
 
 Input: PCAP <br>
 
@@ -786,7 +523,7 @@ only_qtype:
   - 2 
 ```
 
-####  only_qname_suffix: *str[]* <br>
+**only_qname_suffix:** *str[]* <br>
 
 Input: PCAP <br>
 
@@ -810,7 +547,7 @@ only_qname_suffix:
   - .nsone.net
 ```
 
-####  geoloc_notfound: *bool* <br>
+**geoloc_notfound:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -823,7 +560,7 @@ geoloc_notfound: true
 ```
 
 
-####  asn_notfound: *bool* <br>
+**asn_notfound:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -835,7 +572,7 @@ The `asn_notfound` filter usage syntax is:<br>
 asn_notfound: true
 ```
 
-####  dnstap_msg_type: *str* <br>
+**dnstap_msg_type:** *str* <br>
 
 Input: DNSTAP <br>
 
@@ -851,6 +588,8 @@ Example:
 ```yaml
 dnstap_msg_type: "auth"
 ```
+
+#### Examples of DNS policy
 
 Example policy pcap dns JSON:
 
@@ -967,7 +706,7 @@ kind: collection
 ### Network (L2-L3) Analyzer (net)
 **Handler Type**: "net" <br>
 
-**Metrics Group**: <br>
+#### Metrics Group <br>
 
 | Metric Group  | Default | 
 |:-------------:|:-------:|
@@ -977,9 +716,10 @@ kind: collection
 |   `top_ips`   | enabled |
 <br>
 
-**Configuration**: <br>
+#### Configurations <br>
 - Abstract configurations. <br><br>
-  **NET Filter Options**: <br>
+
+#### Filters <br>
 
 |        Filter        |  Type   |    Input     |
 |:--------------------:|:-------:|:------------:|
@@ -988,8 +728,7 @@ kind: collection
 | `only_geoloc_prefix` | *str[]* | PCAP, DNSTAP |
 |  `only_asn_number`   | *str[]* | PCAP, DNSTAP |
 
-
-####  geoloc_notfound: *bool* <br>
+**geoloc_notfound:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -1000,7 +739,7 @@ The `geoloc_notfound` filter usage syntax is:<br>
 geoloc_notfound: true
 ```
 
-####  asn_notfound: *bool* <br>
+**asn_notfound:** *bool* <br>
 
 Input: PCAP <br>
 
@@ -1011,7 +750,7 @@ The `asn_notfound` filter usage syntax is:<br>
 asn_notfound: true
 ```
 
-####  only_geoloc_prefix: *str[]* <br>
+**only_geoloc_prefix:** *str[]* <br>
 
 Input: PCAP <br>
 
@@ -1029,7 +768,7 @@ only_geoloc_prefix:
   - US/CA
 ```
 
-####  only_asn_number: *str[]* <br>
+**only_asn_number:** *str[]* <br>
 
 Input: PCAP <br>
 
@@ -1046,6 +785,8 @@ only_asn_number:
   - 7326
   - 16136
 ```
+
+#### Examples of NET policy
 
 Example policy pcap dns JSON:
 
@@ -1151,14 +892,19 @@ kind: collection
 ### DHCP Analyzer (dhcp)
 **Handler Type**: "dhcp" <br>
 
-**Metrics Group**: No metrics group available<br>
+#### Metrics Group 
 
-**Configuration**: <br>
-- Only abstract configurations. <br><br>
+- No metrics group available <br>
 
-**Filter Options**: No filters available. <br><br>
+#### Configurations <br>
+- Abstract configurations. <br><br>
+
+#### Filters
+- No filters available. <br><br>
 
 Example policy pcap dhcp JSON:
+
+#### Examples of DHCP policy
 
 ```json
 {
@@ -1227,12 +973,16 @@ kind: collection
 ### Packet Capture Analyzer (pcap)
 **Handler Type**: "pcap" <br>
 
-**Metrics Group**: No metrics group available<br>
+#### Metrics Group
+- No metrics group available. <br>
 
-**Configuration**: <br>
-- Abstract configurations. <br><br>
+#### Configurations
+- Abstract configurations. <br>
 
-**Filter Options**: No filters available. <br><br>
+#### Filters
+- No filters available. <br>
+
+#### Examples of PCAP policy
 
 Example policy pcap pcap json:
 
@@ -1304,7 +1054,7 @@ kind: collection
 ### Flow Analyzer (flow)
 **Handler Type**: "flow" <br>
 
-**Metrics Group**: <br>
+#### Metrics Group <br>
 
 |   Metric Group   | Default | 
 |:----------------:|:-------:|
@@ -1315,12 +1065,12 @@ kind: collection
 |  `top_by_bytes`  | enabled |
 <br>
 
-**Configuration**: <br>
+#### Configurations <br>
 - sample_rate_scaling: *bool* <br>
 - recorded_stream: <br> #todo
 - Abstract configurations. <br><br>
 
-#### sample_rate_scaling
+**sample_rate_scaling**
 
 By default, flow metrics are generated by an approximation based on sampling the data. 1 packet every N is analyzed and the prediction of the entire population is made from the sample. If you want to see exactly all the exact data, you can disable `sample_rate_scaling`. <br>
 
@@ -1329,7 +1079,7 @@ The `sample_rate_scaling` filter usage syntax is:<br>
 sample_rate_scaling: false
 ```
 
-**Flow Filter Options**: <br>
+#### Filters <br>
 
 
 |      Filter       |  Type   | Input |
@@ -1342,7 +1092,7 @@ sample_rate_scaling: false
 |  `asn_notfound`   | *bool*  | FLOW  |
 
 
-#### only_devices: *str[]* <br>
+**only_devices:** *str[]* <br>
 
 Input: FLOW <br>
 
@@ -1361,7 +1111,7 @@ only_devices:
   - 192.158.1.38/32
 ```
 
-#### only_ips: *str[]* <br>
+**only_ips:** *str[]* <br>
 
 Input: FLOW <br>
 
@@ -1379,7 +1129,7 @@ only_ips:
   - 192.158.1.38/32
 ```
 
-#### only_ports: *str[]* <br>
+**only_ports:** *str[]* <br>
 
 Input: FLOW <br>
 
@@ -1399,7 +1149,7 @@ only_devices:
 
 ```
 
-#### only_interfaces: *str* <br>
+**only_interfaces:** *str* <br>
 
 Input: FLOW <br>
 
@@ -1419,7 +1169,7 @@ only_interfaces:
 
 ```
 
-####  geoloc_notfound: *bool* <br>
+**geoloc_notfound:** *bool* <br>
 
 Input: FLOW <br>
 
@@ -1430,7 +1180,7 @@ The `geoloc_notfound` filter usage syntax is:<br>
 geoloc_notfound: true
 ```
 
-####  asn_notfound: *bool* <br>
+**asn_notfound:** *bool* <br>
 
 Input: FLOW <br>
 
@@ -1441,6 +1191,8 @@ The `asn_notfound` filter usage syntax is:<br>
 ```yaml
 asn_notfound: true
 ```
+
+#### Examples of FLOW policy
 
 Example policy input flow handler flow JSON:
 

--- a/docs/documentation/running_orb_agent.md
+++ b/docs/documentation/running_orb_agent.md
@@ -1,0 +1,263 @@
+# Running Orb Agent
+
+An Orb agent needs to run on all the infrastructure (computers, servers, switches, VMs, k8s, etc.) to be monitored. It is a small, lightweight Docker process with an embedded [pktvisor agent](https://pktvisor.dev) which connects into the Orb control plane to receive policies and send its metric output.
+
+To run an agent, you will need:
+
+1. Docker, to run the agent image ([ns1labs/orb-agent:develop](https://hub.docker.com/repository/docker/ns1labs/orb-agent))
+2. [Agent Credentials](#agent-credentials), which are provided to you by the Orb UI or REST API after [creating an agent](/docs/#create-an-agent)
+3. The Orb Control Plane host address (e.g. `localhost` or `orb.live`)
+4. The network interface to monitor (e.g. `eth0`)
+
+!!! tip
+
+    If you are unsure which network interface to monitor, you may list the available interfaces on your host. Note that to allow 
+    the agent access to these interfaces, you must run the container with `--net=host`
+    
+
+    === "Linux"
+
+        ``` shell 
+        ip -stats -color -human addr
+        ```
+
+
+    === "OSX"
+
+        ``` shell 
+        ifconfig
+        ```
+
+## Agent credentials
+
+The agent credentials include *three pieces of information*, each of which is a UUID in the form `5dc34ded-6a53-44c0-8d15-7e9c8c95391a`.
+
+1. **Agent ID**, which uniquely identifies the agent.
+2. **Agent Channel ID**, which uniquely identifies the agent's communication channel.
+3. **Agent Key**, which is a private access token for the agent. Note you will only be shown the key once upon creation!
+
+## Sample provisioning commands
+!!! example
+
+    === "Generic"
+
+        Use this command as a template by substituting in the appropriate values:
+
+        ``` shell 
+        docker run -d --net=host
+        -e ORB_CLOUD_ADDRESS=<HOST>
+        -e ORB_CLOUD_MQTT_ID=<AGENTID>
+        -e ORB_CLOUD_MQTT_CHANNEL_ID=<CHANNELID>
+        -e ORB_CLOUD_MQTT_KEY=<AGENTKEY>
+        -e PKTVISOR_PCAP_IFACE_DEFAULT=mock
+        ns1labs/orb-agent:develop
+        ```
+    === "localhost, mock"
+        
+        This command is useful for connecting to a local develop environment, perhaps running on [Docker compose](/install/#orb-with-docker-compose). 
+        Note that the "mock" interface will generate random traffic rather than observe real traffic.
+
+        ``` shell 
+        docker run -d --net=host
+        -e ORB_CLOUD_ADDRESS=localhost
+        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
+        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
+        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
+        -e PKTVISOR_PCAP_IFACE_DEFAULT=mock
+        -e ORB_TLS_VERIFY=false
+        ns1labs/orb-agent:develop
+        ```
+
+    === "orb.live, eth0"
+        
+        This command is similar to one you would use on the orb.live SaaS platform
+
+        ``` shell 
+        docker run -d --net=host
+        -e ORB_CLOUD_ADDRESS=orb.live
+        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
+        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
+        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
+        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
+        ns1labs/orb-agent:develop
+        ```
+
+    === "You may want to run more than one agent on the same node and for that you must specify different pktvisor control ports for them, since the containers run in host networking mode, only one is allowed to run per port. By default, the pktvisor control port runs on port *10853*, but this value can be set through the environment variable `ORB_BACKENDS_PKTVISOR_API_PORT`"
+
+
+        ``` shell 
+        docker run -d --net=host
+        -e ORB_CLOUD_ADDRESS=orb.live
+        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
+        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
+        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
+        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
+        -e ORB_BACKENDS_PKTVISOR_API_PORT=10854
+        ns1labs/orb-agent:develop
+        ```
+
+    === "🎁 BONUS - you can access agent debug logs by passing the -d command"
+
+
+        ``` shell 
+        docker run -d --net=host
+        -e ORB_CLOUD_ADDRESS=orb.live
+        -e ORB_CLOUD_MQTT_ID=7fb96f61-5de1-4f56-99d6-4eb8b43f8bad
+        -e ORB_CLOUD_MQTT_CHANNEL_ID=3e60e85d-4414-44d9-b564-0c1874898a4d
+        -e ORB_CLOUD_MQTT_KEY=44e42d90-aaef-45de-9bc2-2b2581eb30b3
+        -e PKTVISOR_PCAP_IFACE_DEFAULT=eth0
+        ns1labs/orb-agent:develop run -d
+        ```
+
+!!! question
+
+    Is the agent Docker image not starting correctly? Do you have a specific use case? Have you found a bug? Come talk to us [live on Slack](https://join.slack.com/t/ns1labs/shared_invite/zt-qqsm5cb4-9fsq1xa~R3h~nX6W0sJzmA),
+    or [file a GitHub issue here](https://github.com/ns1labs/orb/issues/new/choose).
+
+## Configuration files
+
+Most configuration options can be passed to the container as environment variables, but there are some situations that require a configuration file.
+
+You will need to use a configuration file if:
+
+* You want to assign tags to the agent at the edge
+* You want to setup custom pktvisor Taps
+* You want the agent to [auto-provision](#advanced-auto-provisioning-setup)
+
+The configuration file is written in YAML.
+You can use the latest [template configuration file](https://raw.githubusercontent.com/ns1labs/orb/develop/cmd/agent/agent.example.yaml) as a starting point, or
+start here:
+
+```yaml
+version: "1.0"
+
+# this section is used by pktvisor
+# see https://github.com/ns1labs/pktvisor/blob/develop/RFCs/2021-04-16-75-taps.md
+visor:
+   taps:
+      default_pcap:
+         input_type: pcap
+         config:
+            iface: "eth0"
+            host_spec: "192.168.0.54/32,192.168.0.55/32,127.0.0.1/32"
+
+# this section is used orb-agent
+# most sections and keys are optional
+orb:
+   # these are arbitrary key value pairs used for organization in the control plane and UI
+   tags:
+      region: EU
+      pop: ams02
+      node_type: dns
+   cloud:
+      config:
+         # optionally specify an agent name to use during auto provisioning
+         # hostname will be used if it's not specified here
+         agent_name: my-agent1
+         auto_provision: true
+      api:
+         address: https://orb.live
+         # if auto provisioning, specify API token here (or pass on the command line)
+         token: TOKEN
+      mqtt:
+         address: tls://orb.live:8883
+         # if not auto provisioning, specify agent connection details here
+         id: "AGENT_UUID"
+         key: "AGENT_KEY_UUID"
+         channel_id: "AGENT_CHANNEL_UUID"
+   backends:
+      pktvisor:
+      binary: "/usr/local/sbin/pktvisord"
+      # this example assumes the file is saved as agent.yaml. If your file has another name, you must replace it with the proper name
+      config_file: "/usr/local/orb/etc/agent.yaml"
+```
+
+You must mount your configuration file into the `orb-agent` container. For example, if your configuration file
+is on the host at `/local/orb/agent.yaml`, you can mount it into the container with this command:
+
+```shell
+docker run -v /local/orb:/usr/local/orb/ --net=host \
+      ns1labs/orb-agent:develop run -c /usr/local/orb/agent.yaml
+```
+
+## Advanced auto-provisioning setup
+Some use cases require a way to provision agents directly on edge infrastructure without creating an agent manually in the UI or REST API ahead of time. To do so, you will need to create an API key which can be used by `orb-agent` to provision itself.
+
+!!! warning
+
+    Auto-provisioning is an advanced use case. Most users will find [creating an agent in the UI](/docs/#create-an-agent) easier.
+
+1. If you have not already done so, register a new account with an email address and password at https://HOST/auth/register.
+
+2. Create a `SESSION_TOKEN` with the `EMAIL_ADDRESS` and `PASSWORD` from registration:
+
+        curl --location --request POST 'https://HOST/api/v1/tokens' \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+        "email": "<EMAIL_ADDRESS>",
+        "password": "<PASSWORD>"
+        }'
+
+3. The output from creating a session token looks like this:
+
+        {
+            "token": "SESSION_TOKEN"
+        }
+
+4. Because session tokens expire after 24 hours, you can create a permanent API token for agent provisioning by using the `SESSION_TOKEN` above:
+
+        curl --location --request POST 'https://HOST/api/v1/keys' \
+        --header 'Authorization: <SESSION_TOKEN>' \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+        "type": 2
+        }'
+
+5. The output from creating a `PERMANENT_TOKEN` looks like the following. Please take note of the `id` (used later to revoke) and the `value` (the permanent API token):
+
+        {
+            "id": "710c6a92-b463-42ec-bf24-8ae24eb13081",
+            "value": "PERMANENT_TOKEN",
+            "issued_at": "2021-09-07T15:29:49.70146088Z"
+        }
+
+6. **Currently, the permanent token allows access to all API functionality, not just provisioning.** You can revoke this permanent token at any time with the following call, using the `id` field above:
+
+        curl --location --request DELETE 'HOST:80/api/v1/keys/<PERMANENT_TOKEN_ID>' \
+        --header 'Authorization: <SESSION_TOKEN>'
+
+7. Create a config for Orb and pktvisor taps, for example, `/local/orb/agent.yaml`:
+```yaml
+version: "1.0"
+
+visor:
+   taps:
+      ethernet:
+         input_type: pcap
+         config:
+            iface: "eth0"
+
+orb:
+   db:
+      file: /usr/local/orb/orb-agent.db
+   tags:
+      region: EU
+      pop: ams02
+      node_type: dns
+   cloud:
+      config:
+         agent_name: myagent1
+      api:
+         address: https://HOST
+      mqtt:
+         address: tls://HOST:8883
+```
+
+8. You can now pull and run `ns1labs/orb-agent:develop` to auto-provision, substituting in the `PERMANENT_TOKEN` and optionally configuring agent name and Orb tags. If you don't set the agent name, it will attempt to use a hostname. You must mount the directory to save the agent state database and the config file:
+
+```shell
+docker pull ns1labs/orb-agent:develop
+docker run -v /local/orb:/usr/local/orb/ --net=host \
+       -e ORB_CLOUD_API_TOKEN=<PERMANENT_TOKEN> \
+      ns1labs/orb-agent:develop run -c /usr/local/orb/agent.yaml
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,10 @@ nav:
   - About: 'about.md'
   - Installation: 'install.md'
   - Getting Started: 'getting_started.md'
-  - Documentation: 'docs.md'
+  - Documentation:
+    - Running ORB agent: 'documentation/running_orb_agent.md'
+    - Advanced Policies: 'documentation/advanced_policies.md'
+    - Orb REST API: 'api/orb_rest_api.md'
   - Community: 'contact.md'
 repo_url: https://github.com/ns1labs/orb
 edit_uri: edit/main/docs


### PR DESCRIPTION
mkdocs has a known bug (https://github.com/mkdocs/mkdocs/issues/2780) to the vertical scrollbar for very large content and that's why my suggestion is to subdivide the content of the documentation tab.

Current documentation:

![image](https://user-images.githubusercontent.com/78241475/189955733-1ebdbadb-8009-465c-845b-e062c42c6a91.png)

This pr is a suggestion to leave it like this:

![new_structure](https://user-images.githubusercontent.com/78241475/189957154-8abecc6c-7cd7-4297-bc0f-a59f21612292.gif)


